### PR TITLE
[MAINTAIN-119] fixed php notice message "Undefined index: name ColorItem.php:91 " during migrate

### DIFF
--- a/modules/openy_demo_tcolor/config/install/migrate_plus.migration.openy_demo_taxonomy_term_color.yml
+++ b/modules/openy_demo_tcolor/config/install/migrate_plus.migration.openy_demo_taxonomy_term_color.yml
@@ -89,6 +89,7 @@ process:
     source: language
     default_value: en
   name: name
+  field_color/name: name
   field_color/color: color
   vid:
     plugin: default_value


### PR DESCRIPTION
This should fix [MAINTAIN-119](https://openy.atlassian.net/browse/MAINTAIN-119)

How to check:

- run  drush OpenY installation
- verify that you can't see the message in terminal "[info] Undefined index: name ColorItem.php:91 [588.16 sec, 288.6 MB]
" after "done with 'openy_demo_lp_paragraph_news_posts_listing'" step