### PR TITLE
[MAINTAIN-131] Move submodule from openy_demo_content.

### DIFF
--- a/modules/openy_demo_bfooter/config/install/migrate_plus.migration.openy_demo_block_content_footer.yml
+++ b/modules/openy_demo_bfooter/config/install/migrate_plus.migration.openy_demo_block_content_footer.yml
@@ -1,0 +1,53 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - openy_demo_bfooter
+id: openy_demo_block_content_footer
+migration_tags:
+  - openy_demo_block_content_footer
+migration_group: openy_demo_fblock
+label: 'Create demo basic blocks in the footer'
+migration_dependencies: {}
+source:
+  plugin: embedded_data
+  data_rows:
+    -
+      id: 7
+      code: 'e350fe26-bc73-4c69-af18-a51a052dbcd3'
+      description: 'Footer Social Block'
+      title: ''
+      body: |
+        <ul class="list-inline">
+        	<li><a class="fa fa-facebook" title="Go to YMCA Facebook" href="#">Facebook</a></li>
+        	<li><a class="fa fa-twitter" title="Go to YMCA Twitter" href="#">Twitter</a></li>
+        	<li><a class="fa fa-youtube" title="Go to YMCA Youtube channel" href="#">Youtube</a></li>
+        </ul>
+    -
+      id: 8
+      code: 'cb76bc7c-a957-4b69-96fb-e565ee85f38a'
+      description: 'Footer Copyright Block'
+      title: ''
+      body: |
+        <p>© [current-date:custom:Y] YMCA</p>
+        <p>The YMCA is a 501(c)(3) not-for-profit social services organization dedicated to Youth Development, Healthy Living, and Social Responsibility.</p>
+  ids:
+    id:
+      type: integer
+process:
+  langcode:
+    plugin: default_value
+    source: language
+    default_value: en
+  type:
+    plugin: default_value
+    default_value: basic_block
+  uuid: code
+  info: description
+  field_block_content/value: body
+  field_block_content/format:
+    plugin: default_value
+    default_value: full_html
+destination:
+  plugin: entity:block_content

--- a/modules/openy_demo_bfooter/config/install/migrate_plus.migration_group.openy_demo_fblock.yml
+++ b/modules/openy_demo_bfooter/config/install/migrate_plus.migration_group.openy_demo_fblock.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: openy_demo_fblock
+label: 'Footer Block'
+description: 'Imports blocks that are being used in footer.'
+module: openy_demo_bfooter

--- a/modules/openy_demo_bfooter/openy_demo_bfooter.info.yml
+++ b/modules/openy_demo_bfooter/openy_demo_bfooter.info.yml
@@ -1,0 +1,11 @@
+name: Open Y Demo Block Footer
+description: Stores migrations to import demo Footer blocks.
+type: module
+core_version_requirement: ^8 || ^9
+version: 8.x-1.0
+package: Open Y
+dependencies:
+  - drupal:migrate
+  - migrate_plus:migrate_plus
+  - migrate_tools:migrate_tools
+  - openy_block_basic:openy_block_basic


### PR DESCRIPTION
As OpenY has a direct dependency to `open-y-subprojects/openy_content_core` we will be 100% sure that the needed module is present.