### PR TITLE
Adjust fontawesome icons used for footer content block

### DIFF
--- a/modules/openy_demo_bfooter/config/install/migrate_plus.migration.openy_demo_block_content_footer.yml
+++ b/modules/openy_demo_bfooter/config/install/migrate_plus.migration.openy_demo_block_content_footer.yml
@@ -20,9 +20,9 @@ source:
       title: ''
       body: |
         <ul class="list-inline">
-        	<li><a class="fa fa-facebook" title="Go to YMCA Facebook" href="#">Facebook</a></li>
-        	<li><a class="fa fa-twitter" title="Go to YMCA Twitter" href="#">Twitter</a></li>
-        	<li><a class="fa fa-youtube" title="Go to YMCA Youtube channel" href="#">Youtube</a></li>
+          <li><a title="Go to YMCA Facebook" href="#"><i class="fab fa-facebook"></i></a></li>
+          <li><a title="Go to YMCA Twitter" href="#"><i class="fab fa-twitter"></i></a></li>
+          <li><a title="Go to YMCA Youtube channel" href="#"><i class="fab fa-youtube"></i></a></li>
         </ul>
     -
       id: 8


### PR DESCRIPTION
Related Issues:
https://openy.atlassian.net/browse/MAINTAIN-275
https://www.drupal.org/project/openy_lily/issues/3275770

Fontawesome icons from Social block are missing:
![image](https://user-images.githubusercontent.com/15172796/163807154-0db44d16-a101-4597-a24f-cb249bb1b8e6.png)

Proposed solution: Adjust fontawesome icons classes used.